### PR TITLE
Adds support for querying by git sha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -339,6 +340,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +390,15 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -502,6 +527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +555,46 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -609,10 +683,13 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "git2",
+ "home",
  "once_cell",
  "reqwest",
  "serde",
  "serde_json",
+ "tabwriter",
  "thiserror",
  "tokio",
  "tracing",
@@ -1057,6 +1134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabwriter"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a327282c4f64f6dc37e3bba4c2b6842cc3a992f204fa58d917696a89f691e5f6"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1347,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,7 @@ thiserror = "1.0.52"
 serde = { version = "1.0.193", features = ["derive"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter", "registry", "fmt"] }
+git2 = "0.18.1"
+home = "0.5.9"
+tabwriter = "1.4.0"
 

--- a/src/bin/nightlies.rs
+++ b/src/bin/nightlies.rs
@@ -1,15 +1,18 @@
 use std::fmt::Write;
+use std::io::Write as IoWrite;
 
 use chrono::{DateTime, Duration, Utc, NaiveDateTime, NaiveTime, NaiveDate};
 use clap::Parser;
 use nightlies::{
     nightly::{
-        fetch_docker_registry_tags, find_tags_by_sha, print_tag,
-        query_range,
+        fetch_docker_registry_tags, print_tag,
+        print_nightly,
+        query_range, tags_to_nightlies, find_nightly_by_build_sha,
     },
-    NightlyError,
+    NightlyError, repo::get_first_nightly_containing_change,
 };
-use tracing::{info, level_filters::LevelFilter};
+use tabwriter::TabWriter;
+use tracing::{info, level_filters::LevelFilter, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 fn parse_datetime(s: &str) -> Result<DateTime<Utc>, NightlyError> {
@@ -47,9 +50,14 @@ struct Args {
     #[arg(short, long, default_value_t = false)]
     print_digest: bool,
 
-    /// If the given target_sha exists as a nightly, print the tag
+    /// If the given build_sha exists as a nightly, print the tag
     #[arg(long)]
-    target_sha: Option<String>,
+    build_sha: Option<String>,
+
+    /// Given a sha that exists in the 'main' branch of the datadog-agent repo, print
+    /// the first nightly that contains that sha
+    #[arg(long)]
+    agent_sha: Option<String>,
 
     /// Number of pages to fetch from the docker registry API
     #[arg(long)]
@@ -84,26 +92,38 @@ async fn main() -> Result<(), NightlyError> {
     // If you don't see the dates you're looking for, try increasing the number of pages
     let num_pages = args.num_registry_pages.unwrap_or(1);
     let tags = fetch_docker_registry_tags(num_pages).await?;
+    let nightlies = tags_to_nightlies(&tags);
 
+    let mut tw = TabWriter::new(vec![]);
     // If dates are specified, lets look at that range
     if let Some(from) = args.from_date {
         info!("Querying range: {} - {}", from, args.to_date.unwrap_or(Utc::now()));
         let tags = query_range(&tags, from, args.to_date);
         for t in tags {
-            print_tag(t, args.all_tags, args.print_digest);
+            print_tag(&mut tw, t, args.all_tags, args.print_digest);
         }
-    } else if let Some(target_sha) = args.target_sha {
-        let target_tags = find_tags_by_sha(&tags, &target_sha);
-        for t in target_tags {
-            print_tag(t, args.all_tags, args.print_digest);
+    } else if let Some(build_sha) = args.build_sha {
+        let nightly = find_nightly_by_build_sha(&nightlies, &build_sha);
+        if let Some(nightly) = nightly {
+            print_nightly(&mut tw, &nightly, args.all_tags, args.print_digest);
+        } else {
+            warn!("Could not find nightly for build sha: {}", build_sha)
         }
+    } else if let Some(sha) = args.agent_sha {
+        let nightly = get_first_nightly_containing_change(&nightlies, &sha)?;
+
+        write!(&mut tw, "The first nightly containing the target sha is:\n").expect("Error writing to tabwriter");
+        print_nightly(&mut tw, &nightly, args.all_tags, args.print_digest);
     } else {
         // default is to just display the most recent 7 days
         let tags = query_range(&tags, (Utc::now() - Duration::days(7)).into(), None);
         for t in tags {
-            print_tag(t, args.all_tags, args.print_digest);
+            print_tag(&mut tw, t, args.all_tags, args.print_digest);
         }
     }
+
+    let written = String::from_utf8(tw.into_inner().unwrap()).unwrap();
+    print!("{}", written);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub enum NightlyError {
 
     #[error("Generic Error: {0}")]
     GenericError(String),
+
+    #[error("Git Error: {0}")]
+    GitError(#[from] git2::Error),
 }
 
 pub mod nightly;
+pub mod repo;

--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -1,66 +1,20 @@
 use crate::NightlyError;
 use chrono::{DateTime, Utc};
-use once_cell::sync::Lazy;
 use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{
-    fs,
-    path::{Path, PathBuf}, collections::HashMap,
-};
-use tracing::{debug, warn, info};
+use std::collections::HashMap;
+use tracing::{warn, info};
+
+const URL: &str = "https://hub.docker.com/v2/repositories/datadog/agent-dev/tags";
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct Tag {
     pub name: String,
-
     #[serde(rename = "tag_last_pushed")]
     pub last_pushed: DateTime<Utc>,
-
     pub digest: String,
-
     pub sha: Option<String>,
-}
-
-pub fn merge_tags(tags_a: Vec<Tag>, tags_b: Vec<Tag>) -> Result<Vec<Tag>, crate::NightlyError> {
-    let mut tags = tags_a;
-
-    // Remove duplicates and ensure sorted by struct field last_pushed
-    let mut tags_b: Vec<Tag> = tags_b.into_iter().filter(|t| !tags.contains(t)).collect();
-    tags.append(&mut tags_b);
-    tags.sort_by(|a, b| b.last_pushed.cmp(&a.last_pushed));
-
-    Ok(tags)
-}
-
-const URL: &str = "https://hub.docker.com/v2/repositories/datadog/agent-dev/tags";
-
-static CACHE_FILE: Lazy<PathBuf> = Lazy::new(|| {
-    // get a 'stable' temp dir that can be used to cache the results from previous runs
-    let dir = std::env::temp_dir();
-    PathBuf::from(dir).join("agent_nightlies.json")
-});
-
-pub fn find_nightly_by_build_sha<'a, 'b>(
-    nightlies: &'a [Nightly],
-    build_sha: &'b str,
-) -> Option<&'a Nightly>
-where
-    'b: 'a,
-{
-    info!("Searching for nightly image with sha: {}", build_sha);
-    nightlies.iter().filter(move |nightly| nightly.sha == build_sha).next()
-}
-
-pub fn find_tags_by_build_sha<'a, 'b>(
-    tags: &'a [Tag],
-    build_sha: &'b str,
-) -> impl Iterator<Item = &'a Tag> + 'a
-where
-    'b: 'a,
-{
-    info!("Searching for tag with build sha: {}", build_sha);
-    tags.iter().filter(move |t| t.name.contains(build_sha))
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -76,6 +30,30 @@ pub struct Nightly {
     pub jmx: Tag,
 }
 
+
+pub fn find_nightly_by_build_sha<'a, 'b>(
+    nightlies: &'a [Nightly],
+    build_sha: &'b str,
+) -> Option<&'a Nightly>
+where
+    'b: 'a,
+{
+    info!("Searching for nightly image with sha: {}", build_sha);
+    nightlies.iter().find(move |nightly| nightly.sha == build_sha)
+}
+
+pub fn find_tags_by_build_sha<'a, 'b>(
+    tags: &'a [Tag],
+    build_sha: &'b str,
+) -> impl Iterator<Item = &'a Tag> + 'a
+where
+    'b: 'a,
+{
+    info!("Searching for tag with build sha: {}", build_sha);
+    tags.iter().filter(move |t| t.name.contains(build_sha))
+}
+
+#[must_use]
 pub fn tags_to_nightlies(tags: &[Tag]) -> Vec<Nightly> {
     let mut nightlies: HashMap<String, Vec<Tag>> = HashMap::new();
     for tag in tags {
@@ -86,7 +64,7 @@ pub fn tags_to_nightlies(tags: &[Tag]) -> Vec<Nightly> {
         entry.push(tag.clone());
     }
 
-    let mut nightlies = nightlies.into_iter().map(|(sha, tags)| {
+    let mut nightlies = nightlies.into_iter().filter_map(|(sha, tags)| {
         let mut py3 = None;
         let mut py2 = None;
         let mut py3_jmx = None;
@@ -105,26 +83,22 @@ pub fn tags_to_nightlies(tags: &[Tag]) -> Vec<Nightly> {
                 jmx = Some(tag);
             }
         }
-        match (py3, py2, py3_jmx, py2_jmx, jmx) {
-            (Some(py3), Some(py2), Some(py3_jmx), Some(py2_jmx), Some(jmx)) => {
-                let estimated_last_pushed = py3.last_pushed;
-                Some(Nightly {
-                    sha,
-                    estimated_last_pushed,
-                    py3,
-                    py2,
-                    py3_jmx,
-                    py2_jmx,
-                    jmx,
-                })
-            }
-            _ => {
-                warn!("Missing tags for sha: {}", sha);
-                None
-            }
+        if let (Some(py3), Some(py2), Some(py3_jmx), Some(py2_jmx), Some(jmx)) = (py3, py2, py3_jmx, py2_jmx, jmx) {
+            let estimated_last_pushed = py3.last_pushed;
+            Some(Nightly {
+                sha,
+                estimated_last_pushed,
+                py3,
+                py2,
+                py3_jmx,
+                py2_jmx,
+                jmx,
+            })
+        } else {
+            warn!("Missing tags for sha: {}", sha);
+            None
         }
     })
-    .filter_map(|n| n)
     .collect::<Vec<Nightly>>();
 
     nightlies.sort_by(|a, b| b.estimated_last_pushed.cmp(&a.estimated_last_pushed));
@@ -134,8 +108,14 @@ pub fn tags_to_nightlies(tags: &[Tag]) -> Vec<Nightly> {
 
 /// Fetches the first `num_pages` of results from the docker registry API
 /// Page size is hardcoded to 100
+///
+/// # Panics
+/// - Panics if unexpected data is returned from the docker registry api
+///
+/// # Errors
+/// - Errors if there is a problem fetching data from the docker registry api
 pub async fn fetch_docker_registry_tags(num_pages: usize) -> Result<Vec<Tag>, NightlyError> {
-    let mut url = format!("{}?page_size=100&name=nightly-main-", URL);
+    let mut url = format!("{URL}?page_size=100&name=nightly-main-");
 
     let mut tags: Vec<Tag> = Vec::new();
     let mut num_pages_fetched = 0;
@@ -176,31 +156,6 @@ pub async fn fetch_docker_registry_tags(num_pages: usize) -> Result<Vec<Tag>, Ni
     Ok(tags)
 }
 
-pub fn save_cached_tags(tags: &[Tag]) -> Result<(), crate::NightlyError> {
-    let file: &Path = CACHE_FILE.as_path();
-    fs::write(file, serde_json::to_string_pretty(&tags)?)?;
-    debug!("Updated tags saved to {file}", file = file.display());
-    Ok(())
-}
-
-pub fn load_tags() -> Result<Vec<Tag>, crate::NightlyError> {
-    let file: &Path = CACHE_FILE.as_path();
-    match fs::read_to_string(file) {
-        Ok(file_content) => {
-            let tags: Vec<Tag> = serde_json::from_str(&file_content)?;
-            Ok(tags)
-        }
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                // No cache file found, this is not a concerning error
-            } else {
-                warn!("Cache file reading error: {}", e);
-            }
-            Ok(Vec::new())
-        }
-    }
-}
-
 pub fn query_range(
     tags: &[Tag],
     from_date: DateTime<Utc>,
@@ -217,7 +172,7 @@ pub fn query_range(
     r
 }
 
-pub fn print_nightly<W>(mut writer: W, nightly: &Nightly, all_tags: bool, print_digest: bool) where W : std::io::Write {
+pub fn print<W>(mut writer: W, nightly: &Nightly, all_tags: bool, print_digest: bool) where W : std::io::Write {
     if all_tags {
         print_tag(&mut writer, &nightly.py3_jmx, true, print_digest);
         print_tag(&mut writer, &nightly.py2_jmx, true, print_digest);
@@ -244,10 +199,9 @@ pub fn print_tag<W>(mut writer: W, tag: &Tag, all_tags: bool, print_digest: bool
         if let Some(sha) = &tag.sha {
             write!(
                 writer,
-                ",\tGitHub URL: https://github.com/DataDog/datadog-agent/tree/{}",
-                sha
+                ",\tGitHub URL: https://github.com/DataDog/datadog-agent/tree/{sha}"
             ).expect("Error writing tag to writer");
         }
-        write!(writer, "\n").expect("Error writing tag to writer");
+        writeln!(writer).expect("Error writing tag to writer");
     }
 }

--- a/src/nightly.rs
+++ b/src/nightly.rs
@@ -1,10 +1,15 @@
-use crate::NightlyError;
+use crate::{repo::get_commit_timestamp, NightlyError};
 use chrono::{DateTime, Utc};
+use once_cell::sync::Lazy;
 use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
-use tracing::{warn, info};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+use tracing::{debug, info, warn};
 
 const URL: &str = "https://hub.docker.com/v2/repositories/datadog/agent-dev/tags";
 
@@ -14,22 +19,37 @@ pub struct Tag {
     #[serde(rename = "tag_last_pushed")]
     pub last_pushed: DateTime<Utc>,
     pub digest: String,
-    pub sha: Option<String>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+impl Tag {
+    fn get_sha(&self) -> Option<&str> {
+        if let Some(sha) = self.name.split('-').nth(2) {
+            if sha.len() == 8 {
+                return Some(sha);
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct Nightly {
     pub sha: String,
     pub estimated_last_pushed: DateTime<Utc>,
-    // todo complement this with a lookup of the git commit sha and get the timestamp from that
+    pub sha_timestamp: DateTime<Utc>,
 
-    pub py3: Tag,
-    pub py2: Tag,
-    pub py3_jmx: Tag,
-    pub py2_jmx: Tag,
-    pub jmx: Tag,
+    pub py3: Option<Tag>,
+    pub py2: Option<Tag>,
+    pub py3_jmx: Option<Tag>,
+    pub py2_jmx: Option<Tag>,
+    pub jmx: Option<Tag>,
 }
 
+static CACHE_FILE: Lazy<PathBuf> = Lazy::new(|| {
+    // get a 'stable' temp dir that can be used to cache the results from previous runs
+    let dir = std::env::temp_dir();
+    dir.join("agent_nightlies.json")
+});
 
 pub fn find_nightly_by_build_sha<'a, 'b>(
     nightlies: &'a [Nightly],
@@ -39,7 +59,9 @@ where
     'b: 'a,
 {
     info!("Searching for nightly image with sha: {}", build_sha);
-    nightlies.iter().find(move |nightly| nightly.sha == build_sha)
+    nightlies
+        .iter()
+        .find(move |nightly| nightly.sha == build_sha)
 }
 
 pub fn find_tags_by_build_sha<'a, 'b>(
@@ -53,53 +75,112 @@ where
     tags.iter().filter(move |t| t.name.contains(build_sha))
 }
 
+/// Given a list of tags, find any tags that represent nightlies
+/// not already tracked in 'nightlies' and add them to 'nightlies'
+///
+/// # Errors
+/// - Errors if any of the tags cannot be parsed into a nightly
+/// - Errors if any of the tags are missing a sha
+/// - Errors if any of the tags are missing a timestamp
+pub fn enrich_nightlies(tags: &[Tag], nightlies: &mut Vec<Nightly>) -> Result<(), NightlyError> {
+    let initial_nightlies_len = nightlies.len();
+    let mut nightlies_from_tags: HashMap<String, Vec<Tag>> = HashMap::new();
+    for tag in tags {
+        let Some(sha) = tag.get_sha() else {
+            continue;
+        };
+        let entry = nightlies_from_tags
+            .entry(sha.to_string())
+            .or_insert_with(|| vec![]);
+        entry.push(tag.clone());
+    }
+
+    for (nightly_sha, tags_for_sha) in &nightlies_from_tags {
+        if !nightlies.iter_mut().any(|n| n.sha == *nightly_sha) {
+            let new_nightly = sha_and_tags_to_nightly(nightly_sha, tags_for_sha)?;
+            nightlies.push(new_nightly);
+        }
+    }
+
+    debug!(
+        "Added {} new nightlies from tags",
+        nightlies.len() - initial_nightlies_len
+    );
+
+    Ok(())
+}
+
+fn sha_and_tags_to_nightly(sha: &str, tags: &[Tag]) -> Result<Nightly, NightlyError> {
+    let mut py3 = None;
+    let mut py2 = None;
+    let mut py3_jmx = None;
+    let mut py2_jmx = None;
+    let mut jmx = None;
+    for tag in tags {
+        if tag.name.ends_with("-py3") {
+            py3 = Some(tag);
+        } else if tag.name.ends_with("-py2") {
+            py2 = Some(tag);
+        } else if tag.name.ends_with("-py3-jmx") {
+            py3_jmx = Some(tag);
+        } else if tag.name.ends_with("-py2-jmx") {
+            py2_jmx = Some(tag);
+        } else if tag.name.ends_with("-jmx") {
+            jmx = Some(tag);
+        }
+    }
+    let first_some = py3.or(py2).or(py3_jmx).or(py2_jmx).or(jmx);
+    if let Some(tag) = first_some {
+        let estimated_last_pushed = tag.last_pushed;
+
+        let sha_timestamp = match get_commit_timestamp(sha) {
+            Ok(timestamp) => timestamp,
+            Err(e) => {
+                warn!(
+                    "Error getting commit timestamp for nightly sha: {}, skipping nightly...",
+                    e
+                );
+                return Err(e);
+            }
+        };
+        Ok(Nightly {
+            sha: sha.to_string(),
+            estimated_last_pushed,
+            sha_timestamp,
+            py3: py3.cloned(),
+            py2: py2.cloned(),
+            py3_jmx: py3_jmx.cloned(),
+            py2_jmx: py2_jmx.cloned(),
+            jmx: jmx.cloned(),
+        })
+    } else {
+        Err(NightlyError::GenericError(format!(
+            "Missing tags for sha: {sha}"
+        )))
+    }
+}
+
 #[must_use]
 pub fn tags_to_nightlies(tags: &[Tag]) -> Vec<Nightly> {
     let mut nightlies: HashMap<String, Vec<Tag>> = HashMap::new();
     for tag in tags {
-        let Some(sha) = &tag.sha else {
-            continue
+        let Some(sha) = tag.get_sha() else {
+            continue;
         };
-        let entry = nightlies.entry(sha.clone()).or_insert_with(|| { vec![] });
+        let entry = nightlies.entry(sha.to_string()).or_insert_with(|| vec![]);
         entry.push(tag.clone());
     }
 
-    let mut nightlies = nightlies.into_iter().filter_map(|(sha, tags)| {
-        let mut py3 = None;
-        let mut py2 = None;
-        let mut py3_jmx = None;
-        let mut py2_jmx = None;
-        let mut jmx = None;
-        for tag in tags {
-            if tag.name.ends_with("-py3") {
-                py3 = Some(tag);
-            } else if tag.name.ends_with("-py2") {
-                py2 = Some(tag);
-            } else if tag.name.ends_with("-py3-jmx") {
-                py3_jmx = Some(tag);
-            } else if tag.name.ends_with("-py2-jmx") {
-                py2_jmx = Some(tag);
-            } else if tag.name.ends_with("-jmx") {
-                jmx = Some(tag);
+    let mut nightlies = nightlies
+        .into_iter()
+        .filter_map(|(sha, tags)| match sha_and_tags_to_nightly(&sha, &tags) {
+            Ok(nightly) => Some(nightly),
+            Err(e) => {
+                warn!("Error parsing nightly: {}", e);
+                None
             }
-        }
-        if let (Some(py3), Some(py2), Some(py3_jmx), Some(py2_jmx), Some(jmx)) = (py3, py2, py3_jmx, py2_jmx, jmx) {
-            let estimated_last_pushed = py3.last_pushed;
-            Some(Nightly {
-                sha,
-                estimated_last_pushed,
-                py3,
-                py2,
-                py3_jmx,
-                py2_jmx,
-                jmx,
-            })
-        } else {
-            warn!("Missing tags for sha: {}", sha);
-            None
-        }
-    })
-    .collect::<Vec<Nightly>>();
+        })
+        .collect::<Vec<Nightly>>();
 
     nightlies.sort_by(|a, b| b.estimated_last_pushed.cmp(&a.estimated_last_pushed));
 
@@ -128,20 +209,22 @@ pub async fn fetch_docker_registry_tags(num_pages: usize) -> Result<Vec<Tag>, Ni
         let results = response["results"].as_array().unwrap();
         let mut tag_results: Vec<Tag> = results
             .iter()
-            .filter_map(|t| match serde_json::from_value(t.clone()) {
-                Ok(tag) => Some(tag),
+            .filter_map(|t| match serde_json::from_value::<Tag>(t.clone()) {
+                Ok(tag) => {
+                    if let Some(sha) = tag.name.split('-').nth(2) {
+                        // Skip the 'main' tag that has no sha
+                        // This floats around and isn't useful to us
+                        if sha.is_empty() {
+                            return None;
+                        }
+                    }
+
+                    Some(tag)
+                }
                 Err(e) => {
                     warn!("Error parsing tag: {}", e);
                     None
                 }
-            })
-            .map(|mut tag: Tag| {
-                if let Some(sha) = tag.name.split('-').nth(2) {
-                    if sha.len() == 8 {
-                        tag.sha = Some(sha.to_string());
-                    }
-                }
-                tag
             })
             .collect::<Vec<_>>();
         tags.append(&mut tag_results);
@@ -157,51 +240,119 @@ pub async fn fetch_docker_registry_tags(num_pages: usize) -> Result<Vec<Tag>, Ni
 }
 
 pub fn query_range(
-    tags: &[Tag],
+    nightlies: &[Nightly],
     from_date: DateTime<Utc>,
     to_date: Option<DateTime<Utc>>,
-) -> impl Iterator<Item = &Tag> + '_ {
-    let r = tags.iter().filter(move |t| {
+) -> impl Iterator<Item = &Nightly> + '_ {
+    let r = nightlies.iter().filter(move |n| {
         if let Some(to_date) = to_date {
-            t.last_pushed <= to_date && t.last_pushed >= from_date
+            n.sha_timestamp <= to_date && n.sha_timestamp >= from_date
         } else {
-            t.last_pushed >= from_date
+            n.sha_timestamp >= from_date
         }
     });
 
     r
 }
 
-pub fn print<W>(mut writer: W, nightly: &Nightly, all_tags: bool, print_digest: bool) where W : std::io::Write {
+/// Print the given nightly and optionally all tags
+///
+/// # Panics:
+/// - If the writer encounters an error
+/// - If the nightly is missing a valid image
+pub fn print<W>(mut writer: W, nightly: &Nightly, all_tags: bool, print_digest: bool)
+where
+    W: std::io::Write,
+{
+    let first_valid_image = nightly
+        .py3
+        .as_ref()
+        .or(nightly.py2.as_ref())
+        .or(nightly.py3_jmx.as_ref())
+        .or(nightly.py2_jmx.as_ref())
+        .or(nightly.jmx.as_ref())
+        .unwrap();
+    writeln!(writer, "Nightly: datadog/agent-dev:{},\tSHA Timestamp: {}\tGitHub URL: https://github.com/DataDog/datadog-agent/tree/{}",
+        first_valid_image.name,
+        nightly.sha_timestamp.to_rfc3339(),
+        nightly.sha,
+    ).expect("Error writing nightly to writer");
+
     if all_tags {
-        print_tag(&mut writer, &nightly.py3_jmx, true, print_digest);
-        print_tag(&mut writer, &nightly.py2_jmx, true, print_digest);
-        print_tag(&mut writer, &nightly.py3, true, print_digest);
-        print_tag(&mut writer, &nightly.py2, true, print_digest);
-    } else {
-        print_tag(&mut writer, &nightly.py3_jmx, true, print_digest);
+        if let Some(tag) = &nightly.jmx {
+            print_tag(&mut writer, tag, all_tags, print_digest);
+        }
+        if let Some(tag) = &nightly.py3_jmx {
+            print_tag(&mut writer, tag, all_tags, print_digest);
+        }
+        if let Some(tag) = &nightly.py2_jmx {
+            print_tag(&mut writer, tag, all_tags, print_digest);
+        }
+        if let Some(tag) = &nightly.py3 {
+            print_tag(&mut writer, tag, all_tags, print_digest);
+        }
+        if let Some(tag) = &nightly.py2 {
+            print_tag(&mut writer, tag, all_tags, print_digest);
+        }
     }
 }
 
-pub fn print_tag<W>(mut writer: W, tag: &Tag, all_tags: bool, print_digest: bool) where W : std::io::Write {
+pub fn print_tag<W>(mut writer: W, tag: &Tag, all_tags: bool, print_digest: bool)
+where
+    W: std::io::Write,
+{
     if all_tags || tag.name.ends_with("-py3") {
         let last_pushed = tag.last_pushed.to_rfc3339();
         write!(
             writer,
             "Tag: datadog/agent-dev:{},\tLast Pushed: {}",
             tag.name, last_pushed,
-        ).expect("Error writing tag to writer");
+        )
+        .expect("Error writing tag to writer");
 
         if print_digest {
             write!(writer, ",\tImage Digest: {}", tag.digest).expect("Error writing tag to writer");
         }
 
-        if let Some(sha) = &tag.sha {
-            write!(
-                writer,
-                ",\tGitHub URL: https://github.com/DataDog/datadog-agent/tree/{sha}"
-            ).expect("Error writing tag to writer");
-        }
         writeln!(writer).expect("Error writing tag to writer");
+    }
+}
+
+/// Saves the given nightlies to a cache file
+///
+/// # Errors
+/// - Errors if the cache file cannot be written to
+/// - Errors if the nightlies cannot be serialized to json
+pub fn save_db_to_cache(nightlies: &[Nightly]) -> Result<(), crate::NightlyError> {
+    let file: &Path = CACHE_FILE.as_path();
+    fs::write(file, serde_json::to_string_pretty(&nightlies)?)?;
+    debug!("Updated nightlies saved to {file}", file = file.display());
+    Ok(())
+}
+
+/// Loads nightlies from a cache file
+///
+/// # Errors
+/// - Errors if the cache file cannot be read
+/// - Errors if the nightlies cannot be deserialized from json
+pub fn load_db_from_cache() -> Result<Vec<Nightly>, crate::NightlyError> {
+    let file: &Path = CACHE_FILE.as_path();
+    debug!(
+        "Reading cached nightlies from {file}",
+        file = file.display()
+    );
+    match fs::read_to_string(file) {
+        Ok(file_content) => {
+            let tags: Vec<Nightly> = serde_json::from_str(&file_content)?;
+            Ok(tags)
+        }
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                // No cache file found, this is not a concerning error
+            } else {
+                warn!("Cache file reading error: {}", e);
+            }
+            Ok(Vec::new())
+        }
     }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,97 @@
+use std::path::{Path, PathBuf};
+
+use chrono::DateTime;
+use git2::{Repository, Error, Commit};
+use tracing::{debug, warn};
+
+use crate::{NightlyError, nightly::Nightly};
+
+fn get_agent_repo_path() -> Result<PathBuf, NightlyError> {
+    let home = match home::home_dir() {
+        Some(path) if !path.as_os_str().is_empty() => Some(path),
+        _ => None,
+    };
+    let home = home.ok_or_else(|| Error::from_str("Could not find home directory"))?;
+
+    Ok(Path::new(&home).join("./go/src/github.com/DataDog/datadog-agent"))
+}
+
+fn open_git_repo() -> Result<Repository, NightlyError> {
+    Repository::open(get_agent_repo_path()?).map_err(|e| NightlyError::GitError(e))
+}
+
+/// Starting from the given branch, walk backwards until we find the commit with the given sha
+fn get_commit_by_sha<'a>(repo: &'a Repository, sha: &'a str, branch: &Commit) -> Result<Option<Commit<'a>>, Error> {
+    let branch_time = DateTime::from_timestamp(branch.time().seconds(), 0).expect("git date invalid");
+    debug!("Searching for commit: {} starting from {:?} (timestamp: {})", sha, branch.id(), branch_time);
+    let commit_oid = match repo.revparse_single(sha) {
+        Ok(obj) => obj.id(),
+        Err(e) => {
+            warn!("Error finding sha: {}", e);
+            return Ok(None);
+        }
+    };
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(branch.id())?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+    // revwalk will now walk backwards from the specified branch
+    // until we find our target commit
+
+    for rev in revwalk {
+        let rev = rev?;
+        if rev == commit_oid {
+            debug!("Found commit: {:?}", rev);
+            let commit = repo.find_commit(rev)?;
+            return Ok(Some(commit));
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn friendly_git_may_be_stale_warning(target_sha: &str) {
+    let git_path = get_agent_repo_path().expect("Could not find agent repo path");
+    warn!("Could not find the target commit: {} on 'main' of your datadog-agent checkout at {}", target_sha, git_path.display());
+    warn!("Consider running 'git -C {} fetch --all --tags'", git_path.display());
+}
+
+/// Given a sha that exists in the 'main' branch of the datadog-agent repo, print
+/// the first nightly build that contains that change
+/// nightlies is assumed to be ordered from newest to oldest
+pub fn get_first_nightly_containing_change(nightlies: &Vec<Nightly>, change_sha: &str) -> Result<Nightly, NightlyError> {
+    let repo = open_git_repo()?;
+    let main = repo.find_branch("main", git2::BranchType::Local)?;
+    let head_of_main = main.get().peel_to_commit()?;
+
+    let commit = get_commit_by_sha(&repo, change_sha, &head_of_main)?;
+    let Some(_commit) = commit else {
+        friendly_git_may_be_stale_warning(change_sha);
+        return Err(NightlyError::GenericError(format!("commit '{}' not found on 'main'", change_sha)));
+    };
+
+    let mut containing_nightly: Option<Nightly> = None;
+
+    debug!("Searching for nightly containing sha: {}", change_sha);
+    for nightly in nightlies.iter() {
+        debug!("Checking if nightly-{} (last pushed: {}) contains the target sha", nightly.sha, nightly.estimated_last_pushed);
+
+        let current_nightly_head_object = match repo.revparse_single(nightly.sha.as_str()) {
+            Ok(obj) => obj,
+            Err(e) => {
+                warn!("Error finding nightly sha: {}", e);
+                friendly_git_may_be_stale_warning(nightly.sha.as_str());
+                continue;
+            }
+        };
+        let current_nightly_head_commit = repo.find_commit(current_nightly_head_object.id())?;
+        if let Some(_commit) = get_commit_by_sha(&repo, change_sha, &current_nightly_head_commit)? {
+            containing_nightly = Some(nightly.clone());
+        } else {
+            debug!("Didn't find commit: {} in nightly: {}", change_sha, nightly.sha);
+        }
+    }
+
+
+    containing_nightly.ok_or_else(|| NightlyError::GenericError(format!("No nightly found containing commit: {}", change_sha)))
+}


### PR DESCRIPTION
Now you can specify any commit sha from `datadog-agent`'s `main` branch and get the first nightly build that contains that change.

This relies on a git checkout at the standard go path `$HOME/go/src/github.com/DataDog/datadog-agent`

also starts a refactor to treat nightly builds as one logical unit rather than a collection of tags.